### PR TITLE
Fix pagination with react-bootstrap v0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "^2.3.4",
     "power-assert": "^1.2.0",
     "react": "^0.14.6",
-    "react-bootstrap": "^0.28.2",
+    "react-bootstrap": "^0.29.0",
     "react-dom": "^0.14.6",
     "ts-loader": "^0.7.2",
     "typescript": "^1.8.2",

--- a/src/BootstrapPager.tsx
+++ b/src/BootstrapPager.tsx
@@ -21,8 +21,8 @@ export class BootstrapPager extends React.Component<BootstrapPagerProps, any>{
         maxButtons: DEFAULT_MAX_BUTTONS
     };
 
-    handleSelect = (event, selectedEvent) => {
-        this.props.setPage(selectedEvent.eventKey - 1);
+    handleSelect = (eventKey, event) => {
+        this.props.setPage(eventKey - 1);
     };
 
     getFilteredResults(): number {


### PR DESCRIPTION
This is a quick change to fix pagination with react-bootstrap v0.29.0 or higher.  The signature for `onSelect` [changed](https://github.com/react-bootstrap/react-bootstrap/blob/master/CHANGELOG.md#v0290) to: `(eventKey: any, event: SyntheticEvent) => any`
